### PR TITLE
ssh-agent support based on trezor-agent

### DIFF
--- a/fido2/Makefile
+++ b/fido2/Makefile
@@ -21,6 +21,7 @@ SRC += version.c
 SRC += data_migration.c
 SRC += extensions/extensions.c extensions/solo.c
 SRC += extensions/wallet.c
+SRC += extensions/ssh_agent.c
 
 # Crypto libs
 SRC += ../crypto/sha256/sha256.c ../crypto/micro-ecc/uECC.c ../crypto/tiny-AES-c/aes.c

--- a/fido2/crypto.c
+++ b/fido2/crypto.c
@@ -89,7 +89,7 @@ void crypto_reset_master_secret(void)
 }
 
 
-void crypto_sha256_update(uint8_t * data, size_t len)
+void crypto_sha256_update(const uint8_t * data, size_t len)
 {
     sha256_update(&sha256_ctx, data, len);
 }
@@ -198,7 +198,7 @@ void crypto_ecc256_load_attestation_key(void)
     _key_len = 32;
 }
 
-void crypto_ecc256_sign(uint8_t * data, int len, uint8_t * sig)
+void crypto_ecc256_sign(const uint8_t * data, int len, uint8_t * sig)
 {
     if ( uECC_sign(_signing_key, data, len, sig, _es256_curve) == 0)
     {
@@ -207,7 +207,7 @@ void crypto_ecc256_sign(uint8_t * data, int len, uint8_t * sig)
     }
 }
 
-void crypto_ecc256_load_key(uint8_t * data, int len, uint8_t * data2, int len2)
+void crypto_ecc256_load_key(const uint8_t * data, int len, uint8_t * data2, int len2)
 {
     static uint8_t privkey[32];
     generate_private_key(data,len,data2,len2,privkey);
@@ -256,7 +256,7 @@ fail:
 
 }
 
-void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey)
+void generate_private_key(const uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey)
 {
     crypto_sha256_hmac_init(CRYPTO_MASTER_KEY, 0, privkey);
     crypto_sha256_update(data, len);
@@ -270,7 +270,7 @@ void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, ui
 
 
 /*int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key, uECC_Curve curve);*/
-void crypto_ecc256_derive_public_key(uint8_t * data, int len, uint8_t * x, uint8_t * y)
+void crypto_ecc256_derive_public_key(const uint8_t * data, int len, uint8_t * x, uint8_t * y)
 {
     uint8_t privkey[32];
     uint8_t pubkey[64];

--- a/fido2/crypto.h
+++ b/fido2/crypto.h
@@ -10,7 +10,7 @@
 #include <stddef.h>
 
 void crypto_sha256_init();
-void crypto_sha256_update(uint8_t * data, size_t len);
+void crypto_sha256_update(const uint8_t * data, size_t len);
 void crypto_sha256_update_secret();
 void crypto_sha256_final(uint8_t * hash);
 
@@ -22,17 +22,17 @@ void crypto_sha512_update(const uint8_t * data, size_t len);
 void crypto_sha512_final(uint8_t * hash);
 
 void crypto_ecc256_init();
-void crypto_ecc256_derive_public_key(uint8_t * data, int len, uint8_t * x, uint8_t * y);
+void crypto_ecc256_derive_public_key(const uint8_t * data, int len, uint8_t * x, uint8_t * y);
 void crypto_ecc256_compute_public_key(uint8_t * privkey, uint8_t * pubkey);
 
-void crypto_ecc256_load_key(uint8_t * data, int len, uint8_t * data2, int len2);
+void crypto_ecc256_load_key(const uint8_t * data, int len, uint8_t * data2, int len2);
 void crypto_ecc256_load_attestation_key();
 void crypto_load_external_key(uint8_t * key, int len);
-void crypto_ecc256_sign(uint8_t * data, int len, uint8_t * sig);
+void crypto_ecc256_sign(const uint8_t * data, int len, uint8_t * sig);
 void crypto_ecdsa_sign(uint8_t * data, int len, uint8_t * sig, int MBEDTLS_ECP_ID);
 
 
-void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey);
+void generate_private_key(const uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey);
 void crypto_ecc256_make_key_pair(uint8_t * pubkey, uint8_t * privkey);
 void crypto_ecc256_shared_secret(const uint8_t * pubkey, const uint8_t * privkey, uint8_t * shared_secret);
 

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -94,10 +94,12 @@ uint8_t ctap_get_info(CborEncoder * encoder)
         ret = cbor_encode_uint(&map, RESP_extensions);
         check_ret(ret);
         {
-            ret = cbor_encoder_create_array(&map, &array, 1);
+            ret = cbor_encoder_create_array(&map, &array, 2);
             check_ret(ret);
             {
                 ret = cbor_encode_text_stringz(&array, "hmac-secret");
+                check_ret(ret);
+                ret = cbor_encode_text_stringz(&array, "solo-ssh-agent");
                 check_ret(ret);
             }
             ret = cbor_encoder_close_container(&map, &array);

--- a/fido2/ctaphid.c
+++ b/fido2/ctaphid.c
@@ -17,6 +17,7 @@
 #include "log.h"
 #include "extensions.h"
 #include "version.h"
+#include "ssh_agent.h"
 
 // move custom SHA512 command out,
 // and the following headers too
@@ -801,8 +802,23 @@ uint8_t ctaphid_custom_command(int len, CTAP_RESPONSE * ctap_resp, CTAPHID_WRITE
             printf2(TAG_ERR, "Error, invalid length.\n");
             ctaphid_send_error(wb->cid, CTAP2_ERR_OPERATION_DENIED);
             return 1;
+        break;
 #endif
 
+#ifndef IS_BOOTLOADER
+        case CTAPHID_SSH_AGENT:
+            printf1(TAG_HID,"CTAPHID_SSH_AGENT\n");
+
+            // relies on ctap_response_init at start of function
+            ssh_agent(len, ctap_buffer, ctap_resp);
+
+            wb->bcnt = ctap_resp->length;
+            ctaphid_write(wb, ctap_resp->data, ctap_resp->length);
+            ctaphid_write(wb, NULL, 0);
+
+            return 1;
+        break;
+#endif
 
         }
 

--- a/fido2/ctaphid.h
+++ b/fido2/ctaphid.h
@@ -30,6 +30,7 @@
 #define CTAPHID_GETRNG          (TYPE_INIT | 0x60)
 #define CTAPHID_GETVERSION      (TYPE_INIT | 0x61)
 #define CTAPHID_LOADKEY         (TYPE_INIT | 0x62)
+#define CTAPHID_SSH_AGENT       (TYPE_INIT | 0x63)
 // reserved for debug, not implemented except for HACKER and DEBUG_LEVEl > 0
 #define CTAPHID_PROBE           (TYPE_INIT | 0x70)
 

--- a/fido2/extensions/ssh_agent.c
+++ b/fido2/extensions/ssh_agent.c
@@ -1,0 +1,67 @@
+#include <string.h>
+
+#include "u2f.h"
+#include "ssh_agent.h"
+#include "crypto.h"
+#include "ctap_errors.h"
+#include "device.h"
+
+void ssh_agent(int len, const uint8_t *ctap_buffer, CTAP_RESPONSE *ctap_resp) {
+  const char ssh_agent_name[] = "solo-ssh-agent";
+
+  uint8_t x[32], y[32], sign[64];
+  memset(x,0,sizeof(x));
+  memset(y,0,sizeof(y));
+  memset(sign,0,sizeof(sign));
+
+  if(len < 1) {
+    ctap_resp->data[0] = CTAP2_ERR_MISSING_PARAMETER;
+    ctap_resp->length = 1;
+    return;
+  }
+
+  switch(ctap_buffer[0]) {
+    case SSH_AGENT_LIST_PUBLIC_KEYS:
+      crypto_ecc256_derive_public_key((const uint8_t *)ssh_agent_name, sizeof(ssh_agent_name), x, y);
+
+      ctap_resp->data[0] = CTAP1_ERR_SUCCESS;
+      ctap_resp->data[1] = U2F_EC_FMT_UNCOMPRESSED; // uECC library skips this flag
+      memmove(ctap_resp->data + 2, x, 32);
+      memmove(ctap_resp->data + 34, y, 32);
+      ctap_resp->length = 66;
+
+      return;
+      break;
+
+    case SSH_AGENT_SIGN_REQUEST:
+      if(len > 32+1) {
+        ctap_resp->data[0] = CTAP1_ERR_INVALID_LENGTH;
+        ctap_resp->length = 1;
+        return;
+      }
+
+      int ret = ctap_user_presence_test(5000);
+      if (ret < 1) {
+        ctap_resp->data[0] = CTAP2_ERR_ACTION_TIMEOUT;
+        ctap_resp->length = 1;
+        return;
+      }
+
+      crypto_ecc256_load_key((const uint8_t *)ssh_agent_name, sizeof(ssh_agent_name), NULL, 0);
+
+      crypto_ecc256_sign(ctap_buffer+1, len-1, sign);
+
+      ctap_resp->data[0] = CTAP1_ERR_SUCCESS;
+      memmove(ctap_resp->data + 1, sign, 64);
+      ctap_resp->length = 65;
+      return;
+      break;
+
+    default:
+      ctap_resp->data[0] = CTAP1_ERR_INVALID_PARAMETER;
+      ctap_resp->length = 1;
+      return;
+      break;
+  }
+
+}

--- a/fido2/extensions/ssh_agent.h
+++ b/fido2/extensions/ssh_agent.h
@@ -1,0 +1,11 @@
+#ifndef _SSH_AGENT_H
+#define _SSH_AGENT_H
+
+#include "ctap.h"
+
+#define SSH_AGENT_LIST_PUBLIC_KEYS 11
+#define SSH_AGENT_SIGN_REQUEST     13
+
+void ssh_agent(int len, const uint8_t *ctap_buffer, CTAP_RESPONSE *ctap_resp);
+
+#endif

--- a/targets/stm32l432/build/application.mk
+++ b/targets/stm32l432/build/application.mk
@@ -14,6 +14,7 @@ SRC += ../../fido2/version.c
 SRC += ../../fido2/data_migration.c
 SRC += ../../fido2/extensions/extensions.c ../../fido2/extensions/solo.c
 SRC += ../../fido2/extensions/wallet.c
+SRC += ../../fido2/extensions/ssh_agent.c
 
 # Crypto libs
 SRC += ../../crypto/sha256/sha256.c ../../crypto/micro-ecc/uECC.c ../../crypto/tiny-AES-c/aes.c


### PR DESCRIPTION
Since the solo firmware already supports the nistp256 curve, I added a simple extension to support ssh.

I added the "solo-ssh-agent" ctap2 extension flag to signal support for this extension

I'm using vendor ctaphid command 0x63 to signal ssh agent messages.  ssh agent messages expect at least one byte for the command, and any other bytes are arguments for that command.

Two sub commands are defined: SSH_AGENT_LIST_PUBLIC_KEYS (11), and SSH_AGENT_SIGN_REQUEST (13).

Return hid message contains a error number (such as CTAP1_ERR_SUCCESS), and then the response data.

I'm using crypto_ecc256_derive_public_key/load_key with the string "solo-ssh-agent"

I have it set to require a tap for every ssh key usage.

The other pieces that go along with this PR:

https://github.com/ddrown/solo-python/tree/ssh-agent
https://github.com/ddrown/trezor-agent/tree/solo-ssh-agent

To install the trezor-agent, I've been using:
```
cd trezor-agent
python3 -m venv venv
./venv/bin/pip install .
./venv/bin/pip install ../solo-python/
./venv/bin/pip install agents/solo/
```

To print out the public key:
```
./venv/bin/solo-agent --debug --verbose test@example.com
```

To use the ssh agent:
```
./venv/bin/solo-agent --debug --verbose --foreground --sock-path /run/user/$UID/solo-agent.ssh test@example.com
# in another window
export SSH_AUTH_SOCK=/run/user/$UID/solo-agent.ssh
ssh-add -L
ssh example.com
```